### PR TITLE
feat: Transform Source, fix: OBSWebsocket reset

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "ms-dotnettools.csdevkit",
+    "ms-dotnettools.csharp",
+    "ms-dotnettools.vscode-dotnet-runtime",
+    "ms-dotnettools.vscodeintellicode-csharp"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch & Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "processName": "LogiPluginService",
+      "preLaunchTask": "debug-plugin",
+      "postDebugTask": "stop-loupedeck",
+      "justMyCode": true
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "csharp.preview.improvedLaunchExperience": true,
+    "files.exclude": {
+        ".vscode": false,
+        "**/node_modules": false,
+        "**/.gitattributes": false,
+        "**/.gitignore": false,
+        "**/.prettierrc": false,
+        "**/eslint.config.mjs": false,
+        "**/package-lock.json": false,
+        "**/pnpm-lock.yaml": false,
+        "**/tsconfig.json": false
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,122 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "stop-loupedeck",
+            "type": "shell",
+            "dependsOn": ["stop-pluginservice"],
+            "osx": {
+                "command": "/usr/bin/pkill -x Loupedeck"
+            },
+            "windows": {
+                "command": "Taskkill /IM \"Loupedeck.exe\" /T /F"
+            }
+        },
+        {
+            "label": "stop-pluginservice",
+            "type": "shell",
+            "osx": {
+                "command": "/usr/bin/pkill -x LogiPluginService"
+            },
+            "windows": {
+                "command": "Taskkill /IM \"LogiPluginService.exe\" /T /F"
+            }
+        },
+        {
+            "label": "debug-plugin",
+            "osx": {
+                // "command": "/Applications/Loupedeck.app/Contents/MacOS/Loupedeck"
+                "command": "/Applications/Utilities/LogiPluginService.app/Contents/MacOS/LogiPluginService"
+            },
+            "windows": {
+                "command": "wt 'C:\\Program Files\\Logi\\LogiPluginService\\LogiPluginService.exe'"
+                // "command": "wt 'C:\\Program Files (x86)\\Loupedeck\\Loupedeck2\\configui2\\Loupedeck.exe'"
+            },
+            "type": "shell",
+            "dependsOn": ["build-debug"],
+            "isBackground": true,
+            "problemMatcher": {
+                "owner": "custom",
+                "fileLocation": ["absolute"],
+                "pattern": [
+                    {
+                        "regexp": "^\\d{4}-\\d{2}-\\d{2}T(\\d{2}-\\d{2}-\\d{2})-(\\d+) \\|\\s+(\\d+) \\|\\s+([A-Z]+) \\|\\s+(.*)$",
+                        "severity": 4,
+                        "line": 0,
+                        "column": 1,
+                        "message": 5,
+                        "code": 4
+                    },
+                    {
+                        "regexp": "^\\d{2}-\\d{2}-\\d{2}-(\\d+) \\[CN\\] File name is '(.*)'",
+                        "file": 2,
+                        "message": 2
+                    },
+                    {
+                        "regexp": "^\\d{2}-\\d{2}-\\d{2}-(\\d+) \\[WS\\] (.*)$",
+                        "message": 2
+                    },
+                    {
+                        "regexp": "^\\d{2}-\\d{2}-\\d{2}-(\\d+) Waiting \\(locking\\) main thread\\.\\.\\.$",
+                        "message": 0
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^\\d{2}-\\d{2}-\\d{2}-(\\d+) Initializing Loupedeck connection",
+                    "endsPattern": "^\\d{2}-\\d{2}-\\d{2}-(\\d+) Waiting \\(locking\\) main thread\\.\\.\\.$"
+                }
+            }
+        },
+        {
+            "label": "build-debug",
+            "type": "shell",
+            "command": "dotnet",
+            "osx": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}/ObsStudioPlugin\\src\\ObsStudioPlugin.sln", // Adjust to your path
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary",
+                    "/p:Configuration=Debug",
+                    "/p:Platform=\"Any CPU\""
+                ]
+            },
+            "windows": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}\\ObsStudioPlugin\\src\\ObsStudioPlugin.sln", // Adjust to your path
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary",
+                    "/p:Configuration=Debug"
+                ]
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build-release",
+            "command": "dotnet",
+            "type": "shell",
+            "osx": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}/ObsStudioPlugin\\src\\ObsStudioPlugin.sln", // Adjust to your path
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary",
+                    "/p:Configuration=Release",
+                    "/p:Platform=\"Any CPU\""
+                ]
+            },
+            "windows": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}\\ObsStudioPlugin\\src\\ObsStudioPlugin.sln", // Adjust to your path
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary",
+                    "/p:Configuration=Release"
+                ]
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/ObsStudioPlugin/src/ObsPlugin/Actions/SourceTransformCommand.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/Actions/SourceTransformCommand.cs
@@ -1,0 +1,147 @@
+﻿namespace Loupedeck.ObsStudioPlugin.Actions
+{
+    using System;
+
+    internal class SourceTransformCommand : PluginMultistateDynamicCommand
+    {
+        public const String IMGSceneSelected = "SourceVisibilityOn.svg";
+        public const String IMGSceneUnselected = "SourceVisibilityOff.svg";
+        public const String IMGSceneInaccessible = "SourceDisabled.png";
+        public const String SourceNameUnknown = "Name Not Available";
+
+        private const Int16 SOURCE_UNSELECTED = 0;
+        private const Int16 SOURCE_SELECTED = 1;
+
+        public SourceTransformCommand()
+        {
+            this.Description = "Enables Move Top/Bottom/Lef/Right and Zoom In/Out of a Source";
+            this.GroupName = "2. Sources";
+            _ = this.AddState("Hidden", "Source hidden");
+            _ = this.AddState("Visible", "Source visible");
+        }
+
+        protected override Boolean OnLoad()
+        {
+            this.IsEnabled = false;
+
+            ObsStudioPlugin.Proxy.AppConnected += this.OnAppConnected;
+            ObsStudioPlugin.Proxy.AppDisconnected += this.OnAppDisconnected;
+
+            ObsStudioPlugin.Proxy.AppEvtSceneListChanged += this.OnSceneListChanged;
+            ObsStudioPlugin.Proxy.AppEvtCurrentSceneChanged += this.OnCurrentSceneChanged;
+            ObsStudioPlugin.Proxy.AppEvtSceneNameChanged += this.OnSceneListChanged; //Note using same handler since we just re-generate params
+
+
+            ObsStudioPlugin.Proxy.AppEvtSceneItemVisibilityChanged += this.OnSceneItemVisibilityChanged;
+
+            ObsStudioPlugin.Proxy.AppEvtSceneItemAdded += this.OnSceneItemAdded;
+            ObsStudioPlugin.Proxy.AppEvtSceneItemRemoved += this.OnSceneItemRemoved;
+
+            ObsStudioPlugin.Proxy.AppInputRenamed += this.OnSourceRenamed;
+
+
+            this.OnAppDisconnected(this, null);
+
+            return true;
+        }
+
+        protected override Boolean OnUnload()
+        {
+            ObsStudioPlugin.Proxy.AppConnected -= this.OnAppConnected;
+            ObsStudioPlugin.Proxy.AppDisconnected -= this.OnAppDisconnected;
+
+            ObsStudioPlugin.Proxy.AppEvtSceneListChanged -= this.OnSceneListChanged;
+            ObsStudioPlugin.Proxy.AppEvtCurrentSceneChanged -= this.OnCurrentSceneChanged;
+            ObsStudioPlugin.Proxy.AppEvtSceneNameChanged -= this.OnSceneListChanged;
+
+            ObsStudioPlugin.Proxy.AppEvtSceneItemVisibilityChanged -= this.OnSceneItemVisibilityChanged;
+
+            ObsStudioPlugin.Proxy.AppEvtSceneItemAdded -= this.OnSceneItemAdded;
+            ObsStudioPlugin.Proxy.AppEvtSceneItemRemoved -= this.OnSceneItemRemoved;
+
+            ObsStudioPlugin.Proxy.AppInputRenamed -= this.OnSourceRenamed;
+
+
+            return true;
+        }
+
+        protected override void RunCommand(String actionParameter) => ObsStudioPlugin.Proxy.AppSceneItemVisibilityToggle(actionParameter);
+
+        private void OnSceneListChanged(Object sender, EventArgs e) => this.ResetParameters(true);
+
+        private void OnCurrentSceneChanged(Object sender, EventArgs e) => this.ActionImageChanged();
+
+        private void OnSceneItemAdded(Object sender, SceneItemArgs arg)
+        {
+            this.AddSceneItemParameter(arg.SceneName, arg.ItemName, arg.ItemId);
+            this.ParametersChanged();
+        }
+
+        private void OnSceneItemRemoved(Object sender, SceneItemArgs arg)
+        {
+            var s = SceneItemKey.Encode(ObsStudioPlugin.Proxy.CurrentSceneCollection, arg.SceneName, arg.ItemId,arg.ItemName);
+            this.Plugin.Log.Info($"Removing scene item {s} sources");
+            this.RemoveParameter(s);
+            this.ParametersChanged();
+        }
+
+        //Note: We can possibly do cherry-picking on the parameters but that require quite a bit of code. 
+        private void OnSourceRenamed(Object sender, OldNewStringChangeEventArgs args) => this.ResetParameters(true);
+
+        private void OnAppConnected(Object sender, EventArgs e) => this.IsEnabled = true;
+
+        private void OnAppDisconnected(Object sender, EventArgs e)
+        {
+            this.IsEnabled = false;
+
+            this.ResetParameters(false);
+            this.ActionImageChanged();
+        }
+
+        protected void OnSceneItemVisibilityChanged(Object sender, SceneItemVisibilityChangedArgs arg)
+        {
+            var actionParameter = SceneItemKey.Encode(ObsStudioPlugin.Proxy.CurrentSceneCollection, arg.SceneName, arg.ItemId);
+            _ = this.SetCurrentState(actionParameter, arg.Visible ? SOURCE_SELECTED : SOURCE_UNSELECTED);
+            //this.ActionImageChanged(actionParameter);
+        }
+
+        protected override BitmapImage GetCommandImage(String actionParameter, Int32 stateIndex, PluginImageSize imageSize)
+        {
+            var imageName = IMGSceneInaccessible;
+            if (SceneItemKey.TryParse(actionParameter, out var parsed))
+            {
+                imageName = parsed.Collection != ObsStudioPlugin.Proxy.CurrentSceneCollection || !ObsStudioPlugin.Proxy.AllSceneItems.ContainsKey(actionParameter)
+                    ? IMGSceneInaccessible
+                    : stateIndex == SOURCE_SELECTED ? IMGSceneSelected : IMGSceneUnselected;
+            }
+
+            return EmbeddedResources.ReadBinaryFile(ObsStudioPlugin.ImageResPrefix + imageName).ToImage();
+        }
+
+        private void AddSceneItemParameter(String sceneName, String itemName,Int32 itemId)
+        {
+            var key = SceneItemKey.Encode(ObsStudioPlugin.Proxy.CurrentSceneCollection, sceneName, itemId);
+            this.AddParameter(key, $"{itemName}", $"{this.GroupName}{CommonStrings.SubgroupSeparator}{sceneName}").Description = 
+                        ObsStudioPlugin.Proxy.AllSceneItems[key].Visible ? "Hide" : "Show" + $" source \"{itemName}\" of scene \"{sceneName}\"";
+            this.SetCurrentState(key, ObsStudioPlugin.Proxy.AllSceneItems[key].Visible ? SOURCE_SELECTED : SOURCE_UNSELECTED);
+        }
+
+        private void ResetParameters(Boolean readContent)
+        {
+            this.RemoveAllParameters();
+
+            if (readContent)
+            {
+                this.Plugin.Log.Info($"Adding {ObsStudioPlugin.Proxy.AllSceneItems?.Count} sources");
+
+                foreach (var item in ObsStudioPlugin.Proxy.AllSceneItems)
+                {
+                    this.AddSceneItemParameter(item.Value.SceneName, item.Value.SourceName, item.Value.SourceId);
+                }
+            }
+
+            this.ParametersChanged();
+            this.ActionImageChanged();
+        }
+    }
+}

--- a/ObsStudioPlugin/src/ObsPlugin/Actions/SourceTransformSwitch.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/Actions/SourceTransformSwitch.cs
@@ -1,0 +1,231 @@
+﻿namespace Loupedeck.ObsStudioPlugin.Actions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel.Design;
+    using System.Linq;
+
+    internal class SourceTransformSwitch : ActionEditorCommand
+    {
+
+
+        private const String ControlSceneSelector = "sceneSelector";
+        private const String ControlSourceSelector = "sourceSelector";
+        private const String ControlTransformType  = "transformType";
+        private const String ControlApplyToAllScenes = "useInAllScenes";
+        private readonly String TransformType_Left = "move left";
+        private readonly String TransformType_Right = "move right";
+        private readonly String TransformType_Top = "move top";
+        private readonly String TransformType_bottom = "move bottom";
+        private readonly String TransformType_zoomIn = "zoomIn";
+        private readonly String TransformType_zoomOut = "zoomOut";
+        
+
+        public SourceTransformSwitch()
+        {
+            this.DisplayName = "Source Transform";
+            this.Description = "aaaaaaaaSets the visibility of a specific source to the ON or OFF state. This is particularly useful when creating Multi-Actions (can be found in Custom category) and trying to target a specific state of visibility.";
+            this.GroupName = "";
+            
+            this.ActionEditor.AddControlEx(parameterControl:
+                new ActionEditorListbox(name: ControlSceneSelector, labelText: "Scene:"/*,"Select Scene name"*/)
+                    .SetRequired()
+                );
+            this.ActionEditor.AddControlEx(parameterControl:
+                new ActionEditorListbox(name: ControlSourceSelector, labelText: "Source:"/*, "Select Source name"*/)
+                .SetRequired()
+                );
+            this.ActionEditor.AddControlEx(parameterControl:
+                new ActionEditorListbox(name: ControlTransformType, labelText: "Type:"/*, "Controls, what state source needs to be in"*/)
+                .SetRequired()
+                );
+
+            
+            this.ActionEditor.ListboxItemsRequested += this.OnActionEditorListboxItemsRequested;
+            this.ActionEditor.ControlValueChanged += this.OnActionEditorControlValueChanged;
+        }
+
+        protected override Boolean OnLoad()
+        {
+            ObsStudioPlugin.Proxy.AppConnected += this.OnAppConnected;
+            ObsStudioPlugin.Proxy.AppDisconnected += this.OnAppDisconnected;
+
+            ObsStudioPlugin.Proxy.AppEvtSceneListChanged += this.OnSceneListChanged;
+            ObsStudioPlugin.Proxy.AppEvtSceneNameChanged += this.OnSceneListChanged;
+
+            return true;
+        }
+
+        protected override Boolean OnUnload()
+        {
+            ObsStudioPlugin.Proxy.AppConnected -= this.OnAppConnected;
+            ObsStudioPlugin.Proxy.AppDisconnected -= this.OnAppDisconnected;
+            ObsStudioPlugin.Proxy.AppEvtSceneListChanged -= this.OnSceneListChanged;
+            ObsStudioPlugin.Proxy.AppEvtSceneNameChanged -= this.OnSceneListChanged;
+
+            return true;
+        }
+
+        private void OnSceneListChanged(Object sender, EventArgs e) => this.ActionEditor.ListboxItemsChanged(ControlSceneSelector);
+
+        private void OnActionEditorControlValueChanged(Object sender, ActionEditorControlValueChangedEventArgs e)
+        {
+
+            if (e.ControlName.EqualsNoCase(ControlSceneSelector))
+            {
+                this.ActionEditor.ListboxItemsChanged(ControlSourceSelector);
+                this.Plugin.Log.Info($"Regenerating sources list");
+            }
+            //We set display name ONLY if all controls are set!
+            else if( 
+                    (
+                        e.ControlName.EqualsNoCase(ControlSourceSelector)
+                        || e.ControlName.EqualsNoCase(ControlTransformType)
+                        || e.ControlName.EqualsNoCase(ControlApplyToAllScenes)
+                    )
+                   &&
+                   (
+                    !(e.ActionEditorState.GetControlValue(ControlSceneSelector).IsNullOrEmpty()
+                   || e.ActionEditorState.GetControlValue(ControlSourceSelector).IsNullOrEmpty())
+                   )
+               )
+            {
+                
+                var sourceName = "Unknown";
+                var sceneName = "Unknown";
+                if (SceneItemKey.TryParse(e.ActionEditorState.GetControlValue(ControlSourceSelector), out var parsed))
+                {
+                    sourceName = parsed.SourceName;
+                    sceneName = parsed.Scene;
+                }
+                e.ActionEditorState.SetDisplayName($"{sourceName} ({sceneName})");
+            }
+            
+        }
+
+        private void OnActionEditorListboxItemsRequested(Object sender, ActionEditorListboxItemsRequestedEventArgs e)
+        {
+            /*
+             * This does not work (yet)
+             * e.ActionEditorState.SetEnabled(ControlSceneSelector, ObsStudioPlugin.Proxy.IsAppConnected);
+             * e.ActionEditorState.SetEnabled(ControlSourceSelector, ObsStudioPlugin.Proxy.IsAppConnected);
+             * e.ActionEditorState.SetEnabled(ControlIsSourceVisible, ObsStudioPlugin.Proxy.IsAppConnected);
+            */
+
+            if (e.ControlName.EqualsNoCase(ControlTransformType))
+            {
+                e.AddItem(this.TransformType_Left, this.TransformType_Left, $"Moves Source to left");
+                e.AddItem(this.TransformType_Right, this.TransformType_Right, $"Moves Source to right");
+                e.AddItem(this.TransformType_Top, this.TransformType_Top, $"Moves Source to top");
+                e.AddItem(this.TransformType_bottom, this.TransformType_bottom, $"Moves Source to bottom");
+                e.AddItem(this.TransformType_zoomIn, this.TransformType_zoomIn, $"Zooms_in");
+                e.AddItem(this.TransformType_zoomOut, this.TransformType_zoomOut, $"Zooms_out");
+                
+            }
+            else if (e.ControlName.EqualsNoCase(ControlSceneSelector))
+            {
+                if (!ObsStudioPlugin.Proxy.IsAppConnected)
+                {
+                    e.AddItem("N/A", "No data", "Not connected to OBS");
+                }
+                else
+                {
+                    this.Plugin.Log.Info($"SVS: Adding scenes to {ControlSceneSelector} control");
+
+                    //Unique scenes (those that have sources)
+                    var unique_scenes = new HashSet<String>();
+
+                    foreach (var item in ObsStudioPlugin.Proxy.AllSceneItems)
+                    {
+                        if( ObsStudioPlugin.Proxy.CurrentSceneCollection.EqualsNoCase(item.Value.CollectionName)
+                        && !unique_scenes.Contains(item.Value.SceneName))
+                        {
+                            unique_scenes.Add(item.Value.SceneName);
+                            e.AddItem(item.Value.SceneName, item.Value.SceneName, $"Scene {item.Value.SceneName}");
+                        }
+                    }
+                }
+            }
+            else if (e.ControlName.EqualsNoCase(ControlSourceSelector))
+            {
+                if (!ObsStudioPlugin.Proxy.IsAppConnected)
+                {
+                    //To ensure sources list is empty so that control cannot be saved.
+                    return; 
+                }
+                var selectedScene = e.ActionEditorState.GetControlValue(ControlSceneSelector);
+
+                if (!String.IsNullOrEmpty(selectedScene))
+                {
+                    this.Plugin.Log.Info($"SVS: Adding sources for {selectedScene}");
+                    foreach(var item in ObsStudioPlugin.Proxy.AllSceneItems)
+                    {
+                        if (ObsStudioPlugin.Proxy.CurrentSceneCollection.EqualsNoCase(item.Value.CollectionName)
+                            && selectedScene.EqualsNoCase(item.Value.SceneName))
+                        {
+                            e.AddItem(item.Key, item.Value.SourceName, $"Source {item.Value.SourceName}");
+                        }
+                    }
+                }
+                else
+                {
+                    e.AddItem("N/A", "No Scene Selected", "Select Scene first");
+                }
+            }
+            else
+            {
+                this.Plugin.Log.Error($"Unexpected control name '{e.ControlName}'");
+            }
+        }
+
+        private void OnAppConnected(Object sender, EventArgs e)
+        {
+        }
+
+        private void OnAppDisconnected(Object sender, EventArgs e)
+        {
+        }
+
+        protected override BitmapImage GetCommandImage(ActionEditorActionParameters actionParameters, Int32 imageWidth, Int32 imageHeight)
+        {
+            var imageName = SourceVisibilityCommand.IMGSceneInaccessible;
+
+            if (actionParameters.TryGetString(ControlSourceSelector, out var key) && SceneItemKey.TryParse(key, out var parsed))
+            {
+
+                // TODO: FIX ME: Provide propper images!
+                //var sourceVisible = actionParameters.TryGetString(ControlTransformType, out var vis) && vis == this.Visibility_Show;
+                var sourceVisible = actionParameters.TryGetString(ControlTransformType, out var vis) && vis == "show";
+
+                imageName = parsed.Collection != ObsStudioPlugin.Proxy.CurrentSceneCollection || !ObsStudioPlugin.Proxy.AllSceneItems.ContainsKey(key)
+                    ? SourceVisibilityCommand.IMGSceneInaccessible
+                    : sourceVisible 
+                        ? SourceVisibilityCommand.IMGSceneSelected 
+                        : SourceVisibilityCommand.IMGSceneUnselected;
+            }
+            else
+            {
+                this.Plugin.Log.Warning($"Cannot retreive selected source name from '{actionParameters}'");
+            }
+
+            return EmbeddedResources.ReadBinaryFile(ObsStudioPlugin.ImageResPrefix + imageName).ToImage();
+        }
+
+        protected override Boolean RunCommand(ActionEditorActionParameters actionParameters)
+        {
+            if (actionParameters.TryGetString(ControlSourceSelector, out var key))
+            {
+                actionParameters.TryGetString(ControlTransformType, out var action);
+                ObsStudioPlugin.Proxy.TransformSoure(key, action);
+                //ObsStudioPlugin.Proxy.AppSceneItemVisibilityToggle(key, true, setVisible, actionParameters.TryGetBoolean(ControlApplyToAllScenes, out var applyToAllScenes) && applyToAllScenes);
+
+                return true;
+            }
+            else
+            {
+                this.Plugin.Log.Warning($"Run: Cannot retreive selected source name from '{actionParameters}'");
+                return false;
+            }
+        }
+    }
+}

--- a/ObsStudioPlugin/src/ObsPlugin/Actions/SourceTransformSwitch.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/Actions/SourceTransformSwitch.cs
@@ -1,25 +1,28 @@
 ﻿namespace Loupedeck.ObsStudioPlugin.Actions
 {
     using System;
+    
     using System.Collections.Generic;
     using System.ComponentModel.Design;
     using System.Linq;
 
     internal class SourceTransformSwitch : ActionEditorCommand
     {
-
-
         private const String ControlSceneSelector = "sceneSelector";
         private const String ControlSourceSelector = "sourceSelector";
-        private const String ControlTransformType  = "transformType";
+        private const String ControlTransformType = "transformType";
         private const String ControlApplyToAllScenes = "useInAllScenes";
-        private readonly String TransformType_Left = "move left";
-        private readonly String TransformType_Right = "move right";
-        private readonly String TransformType_Top = "move top";
-        private readonly String TransformType_bottom = "move bottom";
-        private readonly String TransformType_zoomIn = "zoomIn";
-        private readonly String TransformType_zoomOut = "zoomOut";
-        
+
+        // Replace string constants with dictionary mapping strings to enum values
+        private readonly Dictionary<string, ObsAppProxy.SourceTransformAction> TransformActions = new Dictionary<string, ObsAppProxy.SourceTransformAction>
+        {
+            { "move left", ObsAppProxy.SourceTransformAction.MoveLeft },
+            { "move right", ObsAppProxy.SourceTransformAction.MoveRight },
+            { "move top", ObsAppProxy.SourceTransformAction.MoveUp },
+            { "move bottom", ObsAppProxy.SourceTransformAction.MoveDown },
+            { "zoomIn", ObsAppProxy.SourceTransformAction.ZoomIn },
+            { "zoomOut", ObsAppProxy.SourceTransformAction.ZoomOut }
+        };
 
         public SourceTransformSwitch()
         {
@@ -114,13 +117,11 @@
 
             if (e.ControlName.EqualsNoCase(ControlTransformType))
             {
-                e.AddItem(this.TransformType_Left, this.TransformType_Left, $"Moves Source to left");
-                e.AddItem(this.TransformType_Right, this.TransformType_Right, $"Moves Source to right");
-                e.AddItem(this.TransformType_Top, this.TransformType_Top, $"Moves Source to top");
-                e.AddItem(this.TransformType_bottom, this.TransformType_bottom, $"Moves Source to bottom");
-                e.AddItem(this.TransformType_zoomIn, this.TransformType_zoomIn, $"Zooms_in");
-                e.AddItem(this.TransformType_zoomOut, this.TransformType_zoomOut, $"Zooms_out");
-                
+                // Add items using the dictionary keys
+                foreach (var action in TransformActions)
+                {
+                    e.AddItem(action.Key, action.Key, $"Transform: {action.Key}");
+                }
             }
             else if (e.ControlName.EqualsNoCase(ControlSceneSelector))
             {
@@ -215,15 +216,17 @@
         {
             if (actionParameters.TryGetString(ControlSourceSelector, out var key))
             {
-                actionParameters.TryGetString(ControlTransformType, out var action);
-                ObsStudioPlugin.Proxy.TransformSoure(key, action);
-                //ObsStudioPlugin.Proxy.AppSceneItemVisibilityToggle(key, true, setVisible, actionParameters.TryGetBoolean(ControlApplyToAllScenes, out var applyToAllScenes) && applyToAllScenes);
-
-                return true;
+                if (actionParameters.TryGetString(ControlTransformType, out var actionStr) && 
+                    TransformActions.TryGetValue(actionStr, out var transformAction))
+                {
+                    ObsStudioPlugin.Proxy.TransformSoure(key, transformAction);
+                    return true;
+                }
+                return false;
             }
             else
             {
-                this.Plugin.Log.Warning($"Run: Cannot retreive selected source name from '{actionParameters}'");
+                this.Plugin.Log.Warning($"Run: Cannot retrieve selected source name from '{actionParameters}'");
                 return false;
             }
         }

--- a/ObsStudioPlugin/src/ObsPlugin/Actions/UniversalStateSwitch.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/Actions/UniversalStateSwitch.cs
@@ -43,6 +43,20 @@
             return true;
         }
 
+         protected override Boolean ProcessButtonEvent2(ActionEditorActionParameters actionParameter, DeviceButtonEvent2 buttonEvent) {
+            this.Plugin.Log.Info($"ProcessButtonEvent2: {buttonEvent.EventType}");
+            
+            return true;
+        }
+        protected override Boolean ProcessTouchEvent(ActionEditorActionParameters actionParameters, DeviceTouchEvent touchEvent) {
+            
+            this.Plugin.Log.Info($"ProcessTouchEvent: {touchEvent.EventType}");
+             
+            return true;
+        }
+
+    //  
+
         protected override Boolean OnUnload()
         {
             ObsStudioPlugin.Proxy.AppConnected -= this.OnAppConnected;

--- a/ObsStudioPlugin/src/ObsPlugin/ObsAppProxy.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/ObsAppProxy.cs
@@ -18,7 +18,7 @@
         public event EventHandler<EventArgs> AppConnected;
         public event EventHandler<EventArgs> AppDisconnected;
 
-        public Plugin Plugin { get; private set; }
+        public ObsStudioPlugin Plugin { get; private set; }
 
         // Properties
         public Boolean IsAppConnected => this.IsConnected;
@@ -32,7 +32,7 @@
                 Environment.SpecialFolder.CommonPictures
             };
 
-        public ObsAppProxy(Plugin _plugin)
+        public ObsAppProxy(ObsStudioPlugin _plugin)
         {
             this.Plugin = _plugin;
 
@@ -321,6 +321,7 @@
         private void OnAppDisconnected(Object sender, ObsDisconnectionInfo arg)
         {
             this.Plugin.Log.Info($"Entering AppDisconnected. Disconnect reason:\"{arg.DisconnectReason}\"");
+            this.Plugin.OBSWebsocketServerLastDisconnectReason = arg.DisconnectReason;
 
 
             this.RecordStateChanged -= this.OnObsRecordingStateChange;

--- a/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.Install.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.Install.cs
@@ -17,17 +17,18 @@
                 return false;
             }
 
-            this.Log.Info($"Install: OBS Installed: {this.ClientApplication.GetApplicationStatus() == ClientApplicationStatus.Installed}. Ini file exists/good:{this._iniFile.iniFileExists}/{this._iniFile.iniFileGood}");
-
+            this.Log.Info($"Install: OBS Installed: {this.ClientApplication.GetApplicationStatus() == ClientApplicationStatus.Installed}. Ini file exists/good:{this.IniFile.iniFileExists}/{this.IniFile.iniFileGood}");
+            this.IniFile ??= new ObsIniFile(this);
+            
             if (this.ClientApplication.GetApplicationStatus() == ClientApplicationStatus.Installed
-                        && this._iniFile.iniFileExists
-                        && !this._iniFile.iniFileGood
+                        && this.IniFile.iniFileExists
+                        && !this.IniFile.iniFileGood
                         )
             {
                 this.Log.Info("Install: OBS Installed but INI file is bad, fixing");
 
                 //Attempting to fix ini file if it is not good. Can only be done when app is not running (for Portable app we need to know its location first
-                this._iniFile.FixIniFile();
+                this.IniFile.FixIniFile();
             }
 
             this.Update_PluginStatus();

--- a/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.Install.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.Install.cs
@@ -19,16 +19,22 @@
 
             this.Log.Info($"Install: OBS Installed: {this.ClientApplication.GetApplicationStatus() == ClientApplicationStatus.Installed}. Ini file exists/good:{this.IniFile.iniFileExists}/{this.IniFile.iniFileGood}");
             this.IniFile ??= new ObsIniFile(this);
-            
+
             if (this.ClientApplication.GetApplicationStatus() == ClientApplicationStatus.Installed
                         && this.IniFile.iniFileExists
                         && !this.IniFile.iniFileGood
                         )
             {
                 this.Log.Info("Install: OBS Installed but INI file is bad, fixing");
-
+// TODO: REMOVE INIFILE ding und nutze OBSConfigFile inzukunft. 
+// TODO: ON INSTALL: create template configfile oder lade bestehende datei.
                 //Attempting to fix ini file if it is not good. Can only be done when app is not running (for Portable app we need to know its location first
                 this.IniFile.FixIniFile();
+            }
+
+            if(!IoHelpers.FileExists(this.GetPluginDataDirectory() + "config.json")) {
+                IoHelpers.CreateEmptyFile(this.GetPluginDataDirectory() + "config.json");
+                IoHelpers.WriteTextFile(this.GetPluginDataDirectory() + "config.json", "{serverPort: 4455, server: \"localhost\", password: \"\"}");
             }
 
             this.Update_PluginStatus();

--- a/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.cs
@@ -12,7 +12,7 @@ namespace Loupedeck.ObsStudioPlugin
     {
         private readonly String SupportPageUrl = "https://support.logi.com/hc/articles/25522063648407-Other-Plugins-MX-Creative-Console#h_01J4V10DCG2M17YD4STPM3NXFS";
         internal static ObsAppProxy Proxy { get; private set; } 
-        internal  ObsIniFile IniFile { get; private set; }
+        private ObsIniFile IniFile = null;
         // Gets a value indicating whether this is an Universal plugin or an Application plugin.
         public override Boolean UsesApplicationApiOnly => true;
 
@@ -150,10 +150,7 @@ namespace Loupedeck.ObsStudioPlugin
             this.Update_PluginStatus();
         }
 
-        private readonly ObsIniFile _iniFile;
-
         
-
         private void OnApplicationStarted(Object sender, EventArgs e)
         {
             //Main entry point for the plugin's connectivity

--- a/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.csproj
+++ b/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.csproj
@@ -61,6 +61,8 @@
     <Compile Include="Actions\SceneCollectionSelectCommand.cs" />
     <Compile Include="Actions\RecordingToggleCommand.cs" />
     <Compile Include="Actions\ReplayBufferToggleCommand.cs" />
+    <Compile Include="Actions\SourceTransformCommand.cs" />
+    <Compile Include="Actions\SourceTransformSwitch.cs" />
     <Compile Include="ObsAppProxy.cs" />
     <Compile Include="ObsStudioPlugin.Install.cs" />
     <Compile Include="ObsStudioApplication.cs" />

--- a/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.csproj
+++ b/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Support\SceneKey.cs" />
     <Compile Include="Support\SceneItemKey.cs" />
     <Compile Include="Support\SceneItemDescriptor.cs" />
+    <Compile Include="Support\OBSConfigFile.cs" />
     <None Include="Support\Support.TEMPLATE.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -113,7 +114,7 @@
     <EmbeddedResource Include="Icons\StreamingToggleOn.svg" />
     <EmbeddedResource Include="Icons\StudioModeToggleOn.svg" />
     <EmbeddedResource Include="Icons\StudioModeToggleOff.svg" />
-	<EmbeddedResource Include="Icons\StudioModeTransition.svg" />
+    <EmbeddedResource Include="Icons\StudioModeTransition.svg" />
     <EmbeddedResource Include="Icons\VirtualCameraToggleOff.svg" />
     <EmbeddedResource Include="Icons\VirtualCameraToggleOn.svg" />
   </ItemGroup>

--- a/ObsStudioPlugin/src/ObsPlugin/Proxy/ObsAppProxy.Sources.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/Proxy/ObsAppProxy.Sources.cs
@@ -111,10 +111,19 @@
             }
         }
         
+        public enum SourceTransformAction
+        {
+            MoveUp,
+            MoveDown,
+            MoveLeft,
+            MoveRight,
+            ZoomIn,
+            ZoomOut
+        }
 
-        public void TransformSoure(String key, String action){
+        public void TransformSoure(String key, SourceTransformAction action)
+        {
             if (this.IsAppConnected && this.AllSceneItems.ContainsKey(key)) {
-
                 var originalItem = this.AllSceneItems[key];
                 var currentTransform = this.GetSceneItemTransform(originalItem.SceneName, originalItem.SourceId);
                 currentTransform.BoundsWidth = currentTransform.BoundsWidth >= 1 ? currentTransform.BoundsWidth : 1;
@@ -123,35 +132,35 @@
                 this.Plugin.Log.Info($"the old transform. boundWidth:{currentTransform.BoundsWidth}, boundType:{currentTransform.BoundsType}, alignment: {currentTransform.Alignnment}");
                 try
                 {
-                    var zoomFactor = 5;  // Equivalent to zoom_factor in Python
+                    var zoomFactor = 1.05;  // Equivalent to zoom_factor in Python
                     var moveDistance = 5;  // Equivalent to move_distance in Python
                     
                     var originalScaleX = currentTransform.ScaleX;
                     var originalScaleY = currentTransform.ScaleY;
                     var posX = currentTransform.X;
                     var posY = currentTransform.Y;
-
+                    this.Plugin.Log.Info($"old position of '{originalItem.SourceName}': x={posX}, y={posY}, scale_x={currentTransform.ScaleX}, scale_y={currentTransform.ScaleY}");
                     // Adjust position or scale based on mode1600
-                    switch (action.ToLower())
+                    switch (action)
                     {
-                        case "up":
+                        case SourceTransformAction.MoveUp:
                             posY -= moveDistance;
                             break;
-                        case "down":
+                        case SourceTransformAction.MoveDown:
                             posY += moveDistance;
                             break;
-                        case "left":
+                        case SourceTransformAction.MoveLeft:
                             posX -= moveDistance;
                             break;
-                        case "right":
+                        case SourceTransformAction.MoveRight:
                             posX += moveDistance;
                             break;
-                        case "zoom_in":
-                        case "zoom_out":
-                            var newScaleX = action == "zoom_in" ? 
+                        case SourceTransformAction.ZoomIn:
+                        case SourceTransformAction.ZoomOut:
+                            var newScaleX = action == SourceTransformAction.ZoomIn ? 
                                 originalScaleX + zoomFactor : originalScaleX - zoomFactor;
                                 
-                            var newScaleY = action == "zoom_in" ? 
+                            var newScaleY = action == SourceTransformAction.ZoomIn ? 
                                 originalScaleY + zoomFactor : originalScaleY - zoomFactor;
                                 
 

--- a/ObsStudioPlugin/src/ObsPlugin/Proxy/ObsAppProxy.Sources.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/Proxy/ObsAppProxy.Sources.cs
@@ -111,6 +111,80 @@
             }
         }
         
+
+        public void TransformSoure(String key, String action){
+            if (this.IsAppConnected && this.AllSceneItems.ContainsKey(key)) {
+
+                var originalItem = this.AllSceneItems[key];
+                var currentTransform = this.GetSceneItemTransform(originalItem.SceneName, originalItem.SourceId);
+                currentTransform.BoundsWidth = currentTransform.BoundsWidth >= 1 ? currentTransform.BoundsWidth : 1;
+                currentTransform.BoundsHeight = currentTransform.BoundsHeight >= 1 ? currentTransform.BoundsHeight : 1;
+                
+                this.Plugin.Log.Info($"the old transform. boundWidth:{currentTransform.BoundsWidth}, boundType:{currentTransform.BoundsType}, alignment: {currentTransform.Alignnment}");
+                try
+                {
+                    var zoomFactor = 5;  // Equivalent to zoom_factor in Python
+                    var moveDistance = 5;  // Equivalent to move_distance in Python
+                    
+                    var originalScaleX = currentTransform.ScaleX;
+                    var originalScaleY = currentTransform.ScaleY;
+                    var posX = currentTransform.X;
+                    var posY = currentTransform.Y;
+
+                    // Adjust position or scale based on mode1600
+                    switch (action.ToLower())
+                    {
+                        case "up":
+                            posY -= moveDistance;
+                            break;
+                        case "down":
+                            posY += moveDistance;
+                            break;
+                        case "left":
+                            posX -= moveDistance;
+                            break;
+                        case "right":
+                            posX += moveDistance;
+                            break;
+                        case "zoom_in":
+                        case "zoom_out":
+                            var newScaleX = action == "zoom_in" ? 
+                                originalScaleX + zoomFactor : originalScaleX - zoomFactor;
+                                
+                            var newScaleY = action == "zoom_in" ? 
+                                originalScaleY + zoomFactor : originalScaleY - zoomFactor;
+                                
+
+                            // Calculate position shift to keep zoom centered
+                            var sourceWidth = currentTransform.Width;
+                            var sourceHeight = currentTransform.Height;
+                            
+                            var deltaX = sourceWidth * (newScaleX - originalScaleX) / 2;
+                            var deltaY = sourceHeight * (newScaleY - originalScaleY) / 2;
+
+                            posX -= deltaX;
+                            posY -= deltaY;
+
+                            currentTransform.ScaleX = newScaleX;
+                            currentTransform.ScaleY = newScaleY;
+                            break;
+                    }
+
+                    currentTransform.X = posX;
+                    currentTransform.Y = posY;
+                    this.Plugin.Log.Info($"the new transform. boundWidth:{currentTransform.BoundsWidth}, boundType:{currentTransform.BoundsType}, alignment: {currentTransform.Alignnment}");
+                    this.Plugin.Log.Info($"New position of '{originalItem.SourceName}': x={posX}, y={posY}, scale_x={currentTransform.ScaleX}, scale_y={currentTransform.ScaleY}");
+                   this.SetSceneItemTransform(originalItem.SceneName, originalItem.SourceId, currentTransform);
+
+                }
+                catch (Exception ex)
+                {
+                    this.Plugin.Log.Error($"Exception {ex.Message} when adjusting source {key}");
+                }
+            }
+        }
+
+
         private void OnObsSceneItemVisibilityChanged(Object sender, SceneItemEnableStateChangedEventArgs arg)
         {
 

--- a/ObsStudioPlugin/src/ObsPlugin/Proxy/ObsAppProxy.Sources.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/Proxy/ObsAppProxy.Sources.cs
@@ -132,7 +132,7 @@
                 this.Plugin.Log.Info($"the old transform. boundWidth:{currentTransform.BoundsWidth}, boundType:{currentTransform.BoundsType}, alignment: {currentTransform.Alignnment}");
                 try
                 {
-                    var zoomFactor = 1.05;  // Equivalent to zoom_factor in Python
+                    var zoomFactor = 0.05;  // Equivalent to zoom_factor in Python
                     var moveDistance = 5;  // Equivalent to move_distance in Python
                     
                     var originalScaleX = currentTransform.ScaleX;
@@ -165,14 +165,14 @@
                                 
 
                             // Calculate position shift to keep zoom centered
-                            var sourceWidth = currentTransform.Width;
-                            var sourceHeight = currentTransform.Height;
+                            // var sourceWidth = currentTransform.Width;
+                            // var sourceHeight = currentTransform.Height;
                             
-                            var deltaX = sourceWidth * (newScaleX - originalScaleX) / 2;
-                            var deltaY = sourceHeight * (newScaleY - originalScaleY) / 2;
+                            // var deltaX = sourceWidth * (newScaleX - originalScaleX) / 2;
+                            // var deltaY = sourceHeight * (newScaleY - originalScaleY) / 2;
 
-                            posX -= deltaX;
-                            posY -= deltaY;
+                            // posX -= deltaX;
+                            // posY -= deltaY;
 
                             currentTransform.ScaleX = newScaleX;
                             currentTransform.ScaleY = newScaleY;

--- a/ObsStudioPlugin/src/ObsPlugin/Support/OBSConfigFile.cs
+++ b/ObsStudioPlugin/src/ObsPlugin/Support/OBSConfigFile.cs
@@ -1,0 +1,80 @@
+namespace Loupedeck.ObsStudioPlugin {
+    using System.Collections.Generic;
+    using System;
+    using System.Dynamic;
+    using System.IO;
+    
+    class OBSConfigFile {
+        
+        private const String DEFAULT_SERVER = "localhost";
+        private const Int32 DEFAULT_PORT = 4455;
+        private const String CONFIG_FILE_NAME = "config.json";
+        private const String REPLACED_PASSWORD = "*****";
+        public ObsStudioPlugin Plugin { get; private set; }
+
+        public OBSConfigFile(ObsStudioPlugin parent) {
+            this.Plugin = parent;
+            this.LoadConfigFile();
+            
+        }
+
+        private String GetConfigFilePath() => Path.Combine(this.Plugin.GetPluginDataDirectory(), CONFIG_FILE_NAME);
+
+        public Boolean LoadConfigFile() {
+            if (!IoHelpers.FileExists(this.GetConfigFilePath())) {
+                this.CreateTemplateConfigFile();
+                return false;
+            }   
+            String configFile = IoHelpers.ReadTextFile(this.GetConfigFilePath());
+            dynamic config = new ExpandoObject();
+            config = Newtonsoft.Json.JsonConvert.DeserializeObject<ExpandoObject>(configFile);
+            
+            if (config != null) {
+                if (config.serverPort is Int32 && config.server is String && config.password is String) {
+                    if (config.password != REPLACED_PASSWORD) {
+                    this.Plugin.UpdatePluginSettings(config.server, config.serverPort, config.password);
+                    this.SaveConfigFile(config.server, config.serverPort, REPLACED_PASSWORD);
+                    return true;
+                    } else {
+                       // config file is already loaded, maybe we should inform the user.
+                    
+                    }
+                }else {
+                    // config file is not valid, create a new one
+                    this.Plugin.Log.Warning($"Config file ({CONFIG_FILE_NAME}) is not valid, creating a new one. Please update the settings. at: " + this.GetConfigFilePath());
+                }
+            } else {
+                // no config file, create a new one
+                this.Plugin.Log.Warning($"No {CONFIG_FILE_NAME} , creating a new one. Please update the settings. at: " + this.GetConfigFilePath());
+            }
+            this.CreateTemplateConfigFile();
+
+            
+            
+
+            
+
+            return false;
+            
+        }
+
+        public Boolean SaveConfigFile(String server, Int32 port, String password) {
+            dynamic config = new ExpandoObject();
+            config.server = server;
+            config.serverPort = port;
+            config.password = password;
+            String json = Newtonsoft.Json.JsonConvert.SerializeObject(config);
+            IoHelpers.WriteTextFile(CONFIG_FILE_NAME, json);
+            return true;
+        }
+
+        public Boolean CreateTemplateConfigFile() {
+            if (!IoHelpers.FileExists(CONFIG_FILE_NAME)) {
+                IoHelpers.CreateEmptyFile(CONFIG_FILE_NAME);
+            
+            }
+            return IoHelpers.WriteTextFile(CONFIG_FILE_NAME, "{serverPort: 4455, server: \"localhost\", password: \"\"}");
+            
+        }
+    }
+}


### PR DESCRIPTION
With this Pull Request, there are two changes coming:
1. I've added Source Transformation to the features. The idea behind this is to be quickly while streaming being able to adjust my sources position and zoom level. Tested on Windows, works well!
2. I've fixed the bug that resets OBS Websocket Settings on every startup of loupedeck. Cause of that issue is, that OBS Studio deletes the section in the global.ini on startup and shutdown. Therefore the config was from plugins perspective always dirty and a new set of settings as been generated- as Connection Settings were not saved within the Loupedeck Plugin, this was even needed. To address the issue, once we have a working set of settings, I save them to the plugin store. If they get outdated, I reinitialize a new set of settings from the OBS Ini.


I'm really sorry for everything that I might made wrong, this is my very very first open source contribution and the first non-school c# project I've ever worked on 🙈🙏🥳