### PR TITLE
Update dependencies and build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# ignore a plugin pack whereever it be created
+*.lplug4

--- a/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.csproj
+++ b/ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.csproj
@@ -126,10 +126,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="obs-websocket-dotnet" Version="5.0.0.3" />
+    <PackageReference Include="obs-websocket-dotnet" Version="5.0.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Reactive" Version="4.3.2" />
-    <PackageReference Include="Websocket.Client" Version="4.4.43" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
+    <PackageReference Include="Websocket.Client" Version="5.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />

--- a/ObsStudioPlugin/src/ObsPlugin/metadata/LoupedeckPackage.yaml
+++ b/ObsStudioPlugin/src/ObsPlugin/metadata/LoupedeckPackage.yaml
@@ -15,7 +15,7 @@ displayName: OBS Studio
 pluginFileName: ObsStudioPlugin.dll 
 
 # Plugin version.
-version: 6.0.3
+version: 6.1.0
 # Author of the plugin. The author can be a company or an individual developer.
 author: Logitech Europe SA
 


### PR DESCRIPTION
# Description
This PR updates project dependencies and improves build configuration with minor maintenance changes.

## Changes Made
### Files Modified:

- .gitignore
- ObsStudioPlugin/src/ObsPlugin/ObsStudioPlugin.csproj
- ObsStudioPlugin/src/ObsPlugin/metadata/LoupedeckPackage.yaml


### Key Changes:

1. Dependency Update: Updated obs-websocket-dotnet package from version 5.0.0.3 to 5.0.1
2. Build Artifacts: Added *.lplug4 to .gitignore to exclude plugin pack files from version control
3. Package Metadata: Updated package configuration in LoupedeckPackage.yaml Changed the version number to 6.1.0 because of the change in dependencies and avoid problems with marketplace offering an update that isn't reflected in github
 
### Before:

- obs-websocket-dotnet v5.0.0.3
- Plugin pack files potentially tracked in Git

### After:
 - obs-websocket-dotnet v5.0.1 (latest stable)
 - Plugin pack files properly ignored

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Dependency update
- [x] Build/configuration improvement

## Testing
 - Project builds successfully
 - No breaking changes in API compatibility